### PR TITLE
Removes unnecessary padding on main container

### DIFF
--- a/src/routes/(portal)/+layout.svelte
+++ b/src/routes/(portal)/+layout.svelte
@@ -54,7 +54,7 @@
 		<Header />
 	</div>
 	<main
-		class={`container flex-1 mx-auto p-4 ${navbar && navbar.orientation === 'vertical' ? '' : 'pt-8'}`}
+		class={`container flex-1 mx-auto ${navbar && navbar.orientation === 'vertical' ? '' : 'pt-8'}`}
 	>
 		<slot />
 	</main>


### PR DESCRIPTION
Removes the `p-4` class from the main container.

This avoids duplicated padding when the navbar is in horizontal mode, resulting in a cleaner layout.